### PR TITLE
Add variable to allow command line options to be passed to sslh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV HTTPS_HOST localhost
 ENV HTTPS_PORT 8443
 ENV SHADOWSOCKS_HOST localhost
 ENV SHADOWSOCKS_PORT 8388
+ENV CMD_OPTS
 
 RUN apk update && \
        apk add --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ sslh && \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ HTTPS_PORT 8443
 
 SHADOWSOCKS_HOST localhost
 SHADOWSOCKS_PORT 8388
+
+CMD_OPTS (extra command line options when running sslh, defaults to blank)
 ```
 
 ----

--- a/entry.sh
+++ b/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sslh -f -u root --listen $LISTEN_IP:$LISTEN_PORT \
+sslh $CMD_OPTS -f -u root --listen $LISTEN_IP:$LISTEN_PORT \
    --ssh $SSH_HOST:$SSH_PORT \
    --ssl $HTTPS_HOST:$HTTPS_PORT \
    --openvpn $OPENVPN_HOST:$OPENVPN_PORT \


### PR DESCRIPTION
This pull request adds a Docker container variable `CMD_OPTS` (blank by default) which would allow extra command line options to be passed to sslh. This is useful, for example, when the user would like to run sslh with `--transparent` for transparent proxy functionality.